### PR TITLE
expose ./core to tree-shake out the css-analyzer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           node-version: 16
       - run: npm ci
+      - run: npm run build
       - run: npm test
 
   publish-npm:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
+      - run: npm run build
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "maintainability"
   ],
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "type": "module",
   "source": "src/index.js",
@@ -25,8 +26,13 @@
   "module": "./dist/css-code-quality.module.js",
   "unpkg": "./dist/css-code-quality.umd.js",
   "exports": {
-    "require": "./dist/css-code-quality.cjs",
-    "default": "./dist/css-code-quality.modern.js"
+    ".": {
+      "import": "./dist/css-code-quality.modern.js",
+      "require": "./dist/css-code-quality.cjs"
+    },
+    "./core": {
+      "import": "./src/core.js"
+    }
   },
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/src/complexity.js
+++ b/src/complexity.js
@@ -1,6 +1,6 @@
 import { compareSpecificity } from '@projectwallace/css-analyzer'
 
-const guards = [
+export const guards = [
 
   // Complexity per Selector should not differ too much from the most common Complexity
   result => {
@@ -124,7 +124,3 @@ const guards = [
     return outcome
   },
 ]
-
-export {
-  guards
-}

--- a/src/core.js
+++ b/src/core.js
@@ -1,0 +1,47 @@
+import { guards as performanceGuards } from './performance.js'
+import { guards as maintainabilityGuards } from './maintainability.js'
+import { guards as complexityGuards } from './complexity.js'
+
+function calculateScore({ result, guards }) {
+	let score = 100
+	let violations = []
+	let passes = []
+
+	for (const guard of guards) {
+		/** @type {{score: number, actual: number, id: string}} */
+		const outcome = guard(result)
+
+		if (outcome.score > 0) {
+			score -= outcome.score
+			violations.push(outcome)
+		} else {
+			passes.push(outcome)
+		}
+	}
+
+	return {
+		score: Math.max(score, 0),
+		violations,
+		passes,
+	}
+}
+
+export function calculate(analysis) {
+	const performance = calculateScore({ result: analysis, guards: performanceGuards })
+	const maintainability = calculateScore({ result: analysis, guards: maintainabilityGuards })
+	const complexity = calculateScore({ result: analysis, guards: complexityGuards })
+
+	return {
+		/** @deprecated */
+		score: 0,
+		violations: performance.violations
+			.concat(maintainability.violations)
+			.concat(complexity.violations),
+		passes: performance.passes
+			.concat(maintainability.passes)
+			.concat(complexity.passes),
+		performance,
+		maintainability,
+		complexity,
+	}
+}

--- a/src/core.test.js
+++ b/src/core.test.js
@@ -1,0 +1,11 @@
+import * as assert from 'uvu/assert'
+import { suite } from 'uvu'
+import { calculate } from './core.js'
+
+const Core = suite('Core')
+
+Core('exports calculate', () => {
+	assert.is(typeof calculate, 'function')
+})
+
+Core.run()

--- a/src/index.js
+++ b/src/index.js
@@ -1,53 +1,7 @@
 import { analyze } from '@projectwallace/css-analyzer'
-import { guards as performanceGuards } from './performance.js'
-import { guards as maintainabilityGuards } from './maintainability.js'
-import { guards as complexityGuards } from './complexity.js'
+import { calculate as calculateFromAnalysis } from './core.js'
 
-function calculateScore({ result, guards }) {
-  let score = 100
-  let violations = []
-  let passes = []
-
-  for (const guard of guards) {
-    /** @type {{score: number, actual: number, id: string}} */
-    const outcome = guard(result)
-
-    if (outcome.score > 0) {
-      score -= outcome.score
-      violations.push(outcome)
-    } else {
-      passes.push(outcome)
-    }
-  }
-
-  return {
-    score: Math.max(score, 0),
-    violations,
-    passes,
-  }
-}
-
-function calculate(css) {
-  const result = analyze(css)
-
-  const performance = calculateScore({ result, guards: performanceGuards })
-  const maintainability = calculateScore({ result, guards: maintainabilityGuards })
-  const complexity = calculateScore({ result, guards: complexityGuards })
-
-  return {
-    score: 0,
-    violations: performance.violations
-      .concat(maintainability.violations)
-      .concat(complexity.violations),
-    passes: performance.passes
-      .concat(maintainability.passes)
-      .concat(complexity.passes),
-    performance,
-    maintainability,
-    complexity,
-  }
-}
-
-export {
-  calculate
+export function calculate(css) {
+	const analysis = analyze(css)
+	return calculateFromAnalysis(analysis)
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,20 @@
+import * as assert from 'uvu/assert'
+import { suite } from 'uvu'
+import { calculate } from './index.js'
+import { calculate as pkgCalculate } from '../dist/css-code-quality.modern.js'
+
+const Index = suite('Index')
+
+Index('exposes a calculcate function', () => {
+	assert.is(typeof calculate, 'function')
+})
+
+Index.run()
+
+const Package = suite('NPM Package')
+
+Package('exposes a calculate function', () => {
+	assert.is(typeof pkgCalculate, 'function')
+})
+
+Package.run()

--- a/src/maintainability.js
+++ b/src/maintainability.js
@@ -1,4 +1,4 @@
-const guards = [
+export const guards = [
 
   // Source Lines of Code should be low'
   result => {
@@ -148,5 +148,3 @@ const guards = [
     return outcome
   },
 ]
-
-export { guards }

--- a/src/performance.js
+++ b/src/performance.js
@@ -1,4 +1,4 @@
-const guards = [
+export const guards = [
 
   // Should not contain @import rules
   result => ({
@@ -75,5 +75,3 @@ const guards = [
     }
   },
 ]
-
-export { guards }


### PR DESCRIPTION
closes #6 

- Run build before testing in CI
- Test ./dist output as part of `npm test`
- Expose `./core` that accepts the output of `@projectwallace/css-analyzer`