### PR TITLE
fix: correct link to github repo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "repository": {
     "type": "git",
-    "url": "git@github.com:projectwallace/css-code-quality.git"
+    "url": "git+https://@github.com:projectwallace/css-code-quality.git"
   },
   "homepage": "https://github.com/projectwallace/css-code-quality",
   "issues": "https://github.com/projectwallace/css-code-quality/issues",


### PR DESCRIPTION
noticed in https://npmtrends.com/@bramus/specificity-vs-@projectwallace/css-analyzer-vs-@projectwallace/css-code-quality-vs-@projectwallace/css-layer-tree-vs-@projectwallace/format-css-vs-color-sorter-vs-css-time-sort-vs-wallace-cli that there's no link to this repo.