### PR TITLE
update css-analyzer to 7.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@projectwallace/css-analyzer": "^6.0.0"
+        "@projectwallace/css-analyzer": "^7.0.2"
       },
       "devDependencies": {
         "typescript": "^5.7.3",
@@ -82,25 +82,6 @@
       "bin": {
         "specificity": "bin/cli.js"
       }
-    },
-    "node_modules/@bramus/specificity/node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@bramus/specificity/node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "license": "CC0-1.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.0",
@@ -592,13 +573,13 @@
       }
     },
     "node_modules/@projectwallace/css-analyzer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@projectwallace/css-analyzer/-/css-analyzer-6.0.0.tgz",
-      "integrity": "sha512-DMg5VHfmVnoscLeMY2trB3rtNmPPOrGEpDDQ3EKxFxpNBy6HAIm+eE7h776j+QWElKNo2KYNW9225YBKzc/bYA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@projectwallace/css-analyzer/-/css-analyzer-7.0.2.tgz",
+      "integrity": "sha512-YXLcgQfR7Osb0kXN5q7BvPAq/rfhtz8iIL4OJ5IjZ+LElROZlAxBANm22/EzJzv+CxfiZswDBiw6UE1PaJF1yQ==",
       "license": "MIT",
       "dependencies": {
         "@bramus/specificity": "^2.4.1",
-        "css-tree": "^2.3.1"
+        "css-tree": "^3.1.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1235,12 +1216,12 @@
       "license": "MIT"
     },
     "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.0.30",
+        "mdn-data": "2.12.2",
         "source-map-js": "^1.0.1"
       },
       "engines": {
@@ -1553,9 +1534,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
@@ -2105,22 +2086,6 @@
       "integrity": "sha512-cI7AmySy3FGIC59YRusPWnscNr2/M60HKTvE2h63EMGZPdB1LLT2G7OE3XB8tajjX7hVBR0YXUVvTEr4JHtLsg==",
       "requires": {
         "css-tree": "^3.0.0"
-      },
-      "dependencies": {
-        "css-tree": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-          "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-          "requires": {
-            "mdn-data": "2.12.2",
-            "source-map-js": "^1.0.1"
-          }
-        },
-        "mdn-data": {
-          "version": "2.12.2",
-          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-          "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="
-        }
       }
     },
     "@esbuild/aix-ppc64": {
@@ -2355,12 +2320,12 @@
       }
     },
     "@projectwallace/css-analyzer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@projectwallace/css-analyzer/-/css-analyzer-6.0.0.tgz",
-      "integrity": "sha512-DMg5VHfmVnoscLeMY2trB3rtNmPPOrGEpDDQ3EKxFxpNBy6HAIm+eE7h776j+QWElKNo2KYNW9225YBKzc/bYA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@projectwallace/css-analyzer/-/css-analyzer-7.0.2.tgz",
+      "integrity": "sha512-YXLcgQfR7Osb0kXN5q7BvPAq/rfhtz8iIL4OJ5IjZ+LElROZlAxBANm22/EzJzv+CxfiZswDBiw6UE1PaJF1yQ==",
       "requires": {
         "@bramus/specificity": "^2.4.1",
-        "css-tree": "^2.3.1"
+        "css-tree": "^3.1.0"
       }
     },
     "@rollup/pluginutils": {
@@ -2766,11 +2731,11 @@
       "dev": true
     },
     "css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
       "requires": {
-        "mdn-data": "2.0.30",
+        "mdn-data": "2.12.2",
         "source-map-js": "^1.0.1"
       }
     },
@@ -2987,9 +2952,9 @@
       }
     },
     "mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="
     },
     "minimatch": {
       "version": "3.0.8",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@projectwallace/css-analyzer": "^6.0.0"
+    "@projectwallace/css-analyzer": "^7.0.2"
   },
   "devDependencies": {
     "typescript": "^5.7.3",


### PR DESCRIPTION
🌱 reduces install size with ~50 because css-analyzer now only ships a single copy of css-tree. https://github.com/projectwallace/css-analyzer/releases/tag/v7.0.2